### PR TITLE
Updated to handle numbers for version

### DIFF
--- a/build_cwl_workflow.py
+++ b/build_cwl_workflow.py
@@ -48,7 +48,9 @@ def process_value(target, value):
     """
     match target[-1]:
         case "s:version":
-            return re.sub(r'[^a-zA-Z0-9 ]', '_', value)
+            if isinstance(value, str):
+                return value.replace("/", "_")
+            return value
         case _:
             return value
 


### PR DESCRIPTION
Updated CWL builder to handle the `algorithm_version` field provided from the algorithm config as both string and number types.

Testing:

Input used (algorithm version field set to 1.2):
[algorithm_config.yml](https://github.com/MAAP-Project/sardem-sarsen/blob/mlucas/nasa-ogc/nasa/ogc/algorithm_config.yml)

Output generated:
[process_sardem-sarsen_mlucas_nasa-ogc.cwl](https://github.com/MAAP-Project/sardem-sarsen/blob/mlucas/nasa-ogc/cwl_workflows/process_sardem-sarsen_mlucas_nasa-ogc.cwl)
