### PR TITLE
Added option to allow for prebuilt containers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   dockerfile-path:
     description: "Path to Dockerfile"
-    required: true
+    required: false
   deploy-app-pack:
     description: "Flag that controls whether or not to deploy application package"
     required: true
@@ -37,17 +37,14 @@ runs:
         pip list
       shell: bash
 
+    - name: Validate action inputs
+      run: python3 ${{ github.action_path }}/validate_inputs.py
+      shell: bash
+
     - name: Create env variable of lowercase GitHub repo name
       run: |
           GITHUB_REPO_LOWER=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
           echo "GITHUB_REPO_LOWER=$GITHUB_REPO_LOWER" >>${GITHUB_ENV}
-      shell: bash
-
-    - name: Set docker tag environment variable
-      run: |
-          GITHUB_REF_NAME_CLEAN="${GITHUB_REF_NAME//\//_}"
-          DOCKER_TAG="ghcr.io/${{ env.GITHUB_REPO_LOWER }}:${GITHUB_REF_NAME_CLEAN}"
-          echo "DOCKER_TAG=$DOCKER_TAG" >>${GITHUB_ENV}
       shell: bash
 
     - name: Set workflow file name environment variable
@@ -79,6 +76,7 @@ runs:
       shell: bash
 
     - name: Log in to GitHub Container Registry
+      if: ${{ inputs.dockerfile-path != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -86,6 +84,7 @@ runs:
         password: ${{ github.token }}
 
     - name: Build and push algorithm Docker image
+      if: ${{ inputs.dockerfile-path != '' }}
       id: push-algorithm
       uses: docker/build-push-action@v5
       with:

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: bash
 
     - name: Validate action inputs
-      run: source python3 ${{ github.action_path }}/validate_inputs.py
+      run: python3 ${{ github.action_path }}/validate_inputs.py
       shell: bash
       env:
         DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,7 @@ runs:
       shell: bash
       env:
         DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}
+        ALGORITHM_CONFIGURATION_PATH: ${{ inputs.algorithm-configuration-path }}
 
     - name: Create env variable of lowercase GitHub repo name
       run: |

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,11 @@ runs:
         pip list
       shell: bash
 
+    - name: printenv
+      run: |
+        printenv
+      shell: bash
+
     - name: Validate action inputs
       run: python3 ${{ github.action_path }}/validate_inputs.py
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -37,14 +37,11 @@ runs:
         pip list
       shell: bash
 
-    - name: printenv
-      run: |
-        printenv
-      shell: bash
-
     - name: Validate action inputs
       run: python3 ${{ github.action_path }}/validate_inputs.py
       shell: bash
+      env:
+        DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}
 
     - name: Create env variable of lowercase GitHub repo name
       run: |

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: bash
 
     - name: Validate action inputs
-      run: python3 ${{ github.action_path }}/validate_inputs.py
+      run: source python3 ${{ github.action_path }}/validate_inputs.py
       shell: bash
       env:
         DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}

--- a/validate_inputs.py
+++ b/validate_inputs.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+This script validates the inputs for the OGC Application Package Builder action.
+It checks for required inputs, validates file paths, and ensures proper input combinations.
+"""
+
+import os
+import sys
+import re
+from urllib.parse import urlparse
+from pathlib import Path
+
+def validate_algorithm_config_file(inputs):
+    """Validate that the algorithm configuration file is a valid YAML file."""
+    config_path = inputs.get('algorithm-configuration-path', '').strip()
+    if not config_path:
+        print("ERROR: algorithm-configuration-path is required.")
+        return False
+    
+    try:
+        import yaml
+        with open(config_path, 'r') as f:
+            yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        print(f"ERROR: Algorithm configuration file is not valid YAML: {e}")
+        return False
+    except Exception as e:
+        print(f"ERROR: Cannot read algorithm configuration file: {e}")
+        return False
+
+    # If algorithm_container_url is provided in yaml file, there won't be a need to build a container.
+    with open(config_path, 'r') as f:
+        config = yaml.safe_load(f)
+        algorithm_container_url = config.get('algorithm_container_url', '').strip()
+        dockerfile_path = inputs.get('dockerfile-path', '').strip()
+        has_container = bool(algorithm_container_url)
+        has_dockerfile_path = bool(dockerfile_path)
+
+        if has_container and has_dockerfile_path:
+            print("ERROR: algorithm_container_url is specified in the algorithm configuration file, but dockerfile-path is also provided. Only one may be provided.")
+            print(f"  algorithm-container-url: {algorithm_container_url}")
+            print(f"  dockerfile-path: {dockerfile_path}")
+            return False
+        
+        if not has_container and not has_dockerfile_path:
+            print("ERROR: algorithm_container_url or dockerfile-path must be provided.")
+            return False
+
+        if has_container:
+            print(f"Setting DOCKER_TAG environment variable to {algorithm_container_url}")
+            os.environ['DOCKER_TAG'] = algorithm_container_url
+        else:
+            github_repo = os.environ.get('GITHUB_REPOSITORY', '').lower()
+            github_ref_name = os.environ.get('GITHUB_REF_NAME', '')
+            github_ref_name_clean = github_ref_name.replace('/', '_')
+            docker_tag = f"ghcr.io/{github_repo}:{github_ref_name_clean}"
+            print(f"Setting DOCKER_TAG environment variable to {docker_tag}")
+            os.environ['DOCKER_TAG'] = docker_tag
+    
+    return True
+
+
+def main():
+    inputs = {}
+    for key, value in os.environ.items():
+        if key.startswith('INPUT_'):
+            input_name = key[6:].lower().replace('_', '-')
+            inputs[input_name] = value
+    
+    print(f"Inputs received: {list(inputs.keys())}")
+    
+    validations = [
+        ("Algorithm configuration file", validate_algorithm_config_file)
+    ]
+    
+    for validation_name, validation_func in validations:
+        print(f"Running {validation_name} validation...")
+        if not validation_func(inputs):
+            print(f"{validation_name} validation failed")
+            sys.exit(1)
+        print(f"{validation_name} validation passed")
+    
+    print("🎉 All validations passed successfully!")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main() 

--- a/validate_inputs.py
+++ b/validate_inputs.py
@@ -48,14 +48,17 @@ def validate_algorithm_config_file():
 
         if has_container:
             print(f"Setting DOCKER_TAG environment variable to {algorithm_container_url}")
-            os.environ['DOCKER_TAG'] = algorithm_container_url
+            with open(os.environ['GITHUB_ENV'], 'a') as env_file:
+                env_file.write(f"DOCKER_TAG={algorithm_container_url}\n")
+
         else:
             github_repo = os.environ.get('GITHUB_REPOSITORY', '').lower()
             github_ref_name = os.environ.get('GITHUB_REF_NAME', '')
             github_ref_name_clean = github_ref_name.replace('/', '_')
             docker_tag = f"ghcr.io/{github_repo}:{github_ref_name_clean}"
             print(f"Setting DOCKER_TAG environment variable to {docker_tag}")
-            os.environ['DOCKER_TAG'] = docker_tag
+            with open(os.environ['GITHUB_ENV'], 'a') as env_file:
+                env_file.write(f"DOCKER_TAG={docker_tag}\n")
     
     return True
 

--- a/validate_inputs.py
+++ b/validate_inputs.py
@@ -32,7 +32,7 @@ def validate_algorithm_config_file(inputs):
     with open(config_path, 'r') as f:
         config = yaml.safe_load(f)
         algorithm_container_url = config.get('algorithm_container_url', '').strip()
-        dockerfile_path = inputs.get('dockerfile-path', '').strip()
+        dockerfile_path = os.environ.get('DOCKERFILE_PATH', '')
         has_container = bool(algorithm_container_url)
         has_dockerfile_path = bool(dockerfile_path)
 
@@ -60,22 +60,14 @@ def validate_algorithm_config_file(inputs):
     return True
 
 
-def main():
-    inputs = {}
-    for key, value in os.environ.items():
-        if key.startswith('INPUT_'):
-            input_name = key[6:].lower().replace('_', '-')
-            inputs[input_name] = value
-    
-    print(f"Inputs received: {list(inputs.keys())}")
-    
+def main():    
     validations = [
         ("Algorithm configuration file", validate_algorithm_config_file)
     ]
     
     for validation_name, validation_func in validations:
         print(f"Running {validation_name} validation...")
-        if not validation_func(inputs):
+        if not validation_func():
             print(f"{validation_name} validation failed")
             sys.exit(1)
         print(f"{validation_name} validation passed")

--- a/validate_inputs.py
+++ b/validate_inputs.py
@@ -10,9 +10,9 @@ import re
 from urllib.parse import urlparse
 from pathlib import Path
 
-def validate_algorithm_config_file(inputs):
+def validate_algorithm_config_file():
     """Validate that the algorithm configuration file is a valid YAML file."""
-    config_path = inputs.get('algorithm-configuration-path', '').strip()
+    config_path = os.environ.get('ALGORITHM_CONFIGURATION_PATH', '')
     if not config_path:
         print("ERROR: algorithm-configuration-path is required.")
         return False


### PR DESCRIPTION
Added option to allow users to specify prebuilt containers. Users who want to exercise this must specify the container in their algorithm configuration file:

`algorithm_container_url: my_algo_container:main`

The GHA will fail if both `algorithm_container_url` and `dockerfile-path` are provided or if neither are provided.

Closes [#1202](https://app.zenhub.com/workspaces/maap-platform-5ee7f0d1f440de0024cd359b/issues/gh/maap-project/community/1202)